### PR TITLE
Create cmd.run and cmd.action

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -91,7 +91,11 @@ const reducer = createReducer({
       return loop(state
         .setIn(['short', 'loading'], true)
         .setIn(['short', 'failed'], false),
-        Cmd.promise(Api.shortIncrement, Actions.shortIncrementSucceed, Actions.shortIncrementFail, amount)
+        Cmd.run(Api.shortIncrement, {
+          successActionCreator: Actions.shortIncrementSucceed,
+          failActionCreator: Actions.shortIncrementFail,
+          args: [amount]
+        })
     )
   },
 
@@ -118,7 +122,11 @@ const reducer = createReducer({
     return loop(state
       .setIn(['long', 'loading'], true)
       .setIn(['long', 'failed'], false),
-    Cmd.promise(Api.longIncrement, Actions.longIncrementSucceed, Actions.longIncrementFail, amount))
+    Cmd.run(Api.longIncrement, {
+      successActionCreator: Actions.longIncrementSucceed,
+      failActionCreator: Actions.longIncrementFail,
+      args: [amount]
+    }))
   },
 
   [Actions.longIncrementSucceed]: (state, amount) => {
@@ -147,8 +155,8 @@ const reducer = createReducer({
     console.log('both start');
     return loop(state,
       Cmd.batch([
-        Cmd.constant(Actions.shortIncrementStart(amount)),
-        Cmd.constant(Actions.longIncrementStart(amount)),
+        Cmd.action(Actions.shortIncrementStart(amount)),
+        Cmd.action(Actions.longIncrementStart(amount)),
       ])
   )},
 }, initialState);


### PR DESCRIPTION
Deprecating Cmd.call, Cmd.arbitrary, and Cmd.promise in favor of Cmd.run.
Renaming Cmd.constant to Cmd.action.
Commenting out Cmd.callback (which was not public yet) to revisit at a later date.

All old types still work, but cause console warnings and will be removed in next major version.

Cmd.run is similar to the 3 types it is replacing, but it figures out if the call is synchronous or not based on the return value (if it's a promise or not), and it makes action creators optional. Now the user doesn't need to choose between 3 Cmd types to run a function. Cmd.call vs promise is decided by if the return value is a promise, and Cmd.arbitrary would be omitting the action creators. 

Additionally, it replaces the long parameter list with an options object, which should be easier to use. It has signature Cmd.run(func, options)

options currently include successActionCreator (optional), failActionCreator (optional), args (optional array of params for func), and forceSync (default false).

the args option will be used as the parameter list for func (via func.apply(args))

forceSync can be used to tell wrapping batches/sequences not to wait for 

